### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/paulwzela/a4ddf35b-dae5-43ef-a547-7c07f9e6ef65/5a8d6d15-e97b-4ef3-9f32-7d2a8c774dbf/_apis/work/boardbadge/5d047073-e863-4ee2-a8d4-8c6ff808d40f)](https://dev.azure.com/paulwzela/a4ddf35b-dae5-43ef-a547-7c07f9e6ef65/_boards/board/t/5a8d6d15-e97b-4ef3-9f32-7d2a8c774dbf/Microsoft.RequirementCategory)
 # Sources with Dockerfile to assemble the docker image.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/paulwzela/a4ddf35b-dae5-43ef-a547-7c07f9e6ef65/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.